### PR TITLE
Rework trials allocation UI for mobile-first clarity (sticky header + collapsible trial cards)

### DIFF
--- a/trials-multiplayer.html
+++ b/trials-multiplayer.html
@@ -107,6 +107,78 @@
       .highlight { font-size: 1.25rem !important; }
       .trial-selection-btn { padding: 0.875rem !important; min-height: 60px; }
     }
+
+    .allocation-sticky-header {
+      position: sticky;
+      top: 0.5rem;
+      z-index: 20;
+      backdrop-filter: blur(8px);
+    }
+    .trial-card {
+      border: 1px solid var(--border);
+      border-radius: 10px;
+      background: var(--card-bg);
+      overflow: hidden;
+    }
+    .trial-card summary {
+      list-style: none;
+      cursor: pointer;
+      padding: 0.75rem;
+    }
+    .trial-card summary::-webkit-details-marker { display: none; }
+    .trial-adjust-row {
+      display: grid;
+      grid-template-columns: 1fr auto;
+      gap: 0.5rem;
+      align-items: center;
+      padding: 0.5rem 0;
+      border-top: 1px solid rgba(255, 255, 255, 0.08);
+    }
+    .trial-adjust-controls {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.35rem;
+    }
+    .trial-adjust-controls button {
+      min-height: 34px;
+      min-width: 34px;
+      padding: 0;
+      font-size: 1.1rem;
+      line-height: 1;
+    }
+    .trial-adjust-controls input[type="number"] {
+      width: 70px;
+      padding: 0.45rem;
+      text-align: center;
+      font-size: 0.95rem;
+    }
+    .wizard-compact-list {
+      display: flex;
+      gap: 0.35rem;
+      flex-wrap: wrap;
+      margin-top: 0.4rem;
+    }
+    .wizard-compact-chip {
+      display: inline-flex;
+      align-items: center;
+      gap: 0.25rem;
+      padding: 0.2rem 0.35rem;
+      border-radius: 999px;
+      font-size: 0.7rem;
+      border: 1px solid rgba(255,255,255,0.2);
+      background: rgba(255,255,255,0.05);
+    }
+    .wizard-initial {
+      width: 18px;
+      height: 18px;
+      border-radius: 50%;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
+      color: #0f172a;
+      font-weight: 700;
+      font-size: 0.62rem;
+    }
   </style>
 </head>
 <body>
@@ -702,7 +774,6 @@
         return initial;
       });
       const [isLocked, setIsLocked] = useState(!!myPlayer.locked);
-      const [selectedTrial, setSelectedTrial] = useState(null);
 
       const myDomains = myPlayer.domains || emptyDomains();
 
@@ -775,6 +846,35 @@
         return { type: 'error', message: `✗ Invalid: This allocation doesn't meet the trial requirements` };
       };
 
+      const clampAllocation = (trialId, domain, nextValue) => {
+        const trialAlloc = allocations[trialId] || {};
+        const currentAlloc = trialAlloc[domain] || 0;
+        const remaining = remainingByDomain[domain] || 0;
+        const maxAllowable = Math.max(0, remaining + currentAlloc);
+        return Math.max(0, Math.min(maxAllowable, nextValue));
+      };
+
+      const nudgeAllocation = (trialId, domain, delta) => {
+        const trialAlloc = allocations[trialId] || {};
+        const currentAlloc = trialAlloc[domain] || 0;
+        const clamped = clampAllocation(trialId, domain, currentAlloc + delta);
+        updateAllocation(trialId, domain, clamped);
+      };
+
+      const getWizardStyle = (name = '') => {
+        let hash = 0;
+        for (let i = 0; i < name.length; i++) hash = name.charCodeAt(i) + ((hash << 5) - hash);
+        const hue = Math.abs(hash) % 360;
+        return { background: `hsl(${hue}, 78%, 72%)` };
+      };
+
+      const getInitials = (name = '?') => {
+        const parts = name.trim().split(/\s+/).filter(Boolean);
+        if (parts.length === 0) return '?';
+        if (parts.length === 1) return parts[0].slice(0, 2).toUpperCase();
+        return (parts[0][0] + parts[parts.length - 1][0]).toUpperCase();
+      };
+
       return (
         <div className="stack">
           <div className="card">
@@ -802,191 +902,146 @@
             </div>
           </div>
 
-          {/* All Wizards Power Reference Table (public info) */}
-          <div className="card" style={{ overflowX: 'auto' }}>
-            <h4>All {TEXT.playerNounPlural}' Domain Power</h4>
-            <table className="reference-table" style={{ width: '100%', marginTop: '1rem', minWidth: '600px' }}>
-              <thead>
-                <tr style={{ borderBottom: '2px solid var(--border)' }}>
-                  <th style={{ padding: '0.75rem', textAlign: 'left' }}>{TEXT.playerNoun}</th>
-                  {Object.entries(DOMAIN_NAMES).map(([key, name]) => (
-                    <th key={key} style={{ padding: '0.75rem', textAlign: 'center', fontSize: '0.85rem' }}>{name}</th>
-                  ))}
-                  <th style={{ padding: '0.75rem', textAlign: 'center' }}>Total</th>
-                </tr>
-              </thead>
-              <tbody>
-                {players.map(w => (
-                  <tr key={w.id} style={{
-                    borderBottom: '1px solid var(--border)',
-                    background: w.id === MY_ID ? 'var(--card-bg-hover)' : 'transparent'
-                  }}>
-                    <td style={{ padding: '0.75rem', fontWeight: 600 }}>
-                      {w.name} {w.id === MY_ID ? '(you)' : ''} {w.locked && '🔒'}
-                    </td>
-                    {Object.keys(DOMAIN_NAMES).map(domainKey => (
-                      <td key={domainKey} style={{ padding: '0.75rem', textAlign: 'center' }}>
-                        {w.domains[domainKey] || 0}
-                      </td>
-                    ))}
-                    <td style={{ padding: '0.75rem', textAlign: 'center', fontWeight: 700 }}>
-                      {Object.values(w.domains).reduce((sum, v) => sum + v, 0)}
-                    </td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </div>
-
-          {/* Your allocation area */}
-          <div className="grid voting-two-column" style={{ gridTemplateColumns: isLocked ? '1fr' : '1fr 1fr', gap: '1.5rem' }}>
-            <div className="stack">
-              {isLocked && (
-                <div className="warning-box"><strong>Locked:</strong> Unlock to make changes</div>
-              )}
-
-              {/* Remaining Power */}
-              <div className="card">
-                <h4>Your Remaining Power</h4>
-                <div className="domain-grid" style={{ marginTop: '0.75rem' }}>
-                  {Object.entries(myDomains).map(([domain, capacity]) => {
-                    const remaining = remainingByDomain[domain] || 0;
-                    return (
-                      <div key={domain} className="domain-item">
-                        <div style={{ textAlign: 'center' }}>
-                          <div className="small muted">{DOMAIN_NAMES[domain] || domain}</div>
-                          <div className="highlight" style={{ fontSize: '1.5rem', fontWeight: 700, marginTop: '0.25rem' }}>
-                            <span style={{ color: remaining === 0 ? 'var(--text-dim)' : undefined }}>{remaining}</span>
-                            <span className="small muted"> / {capacity}</span>
-                          </div>
-                        </div>
-                      </div>
-                    );
-                  })}
-                </div>
+          <div className="allocation-sticky-header card">
+            {isLocked && (
+              <div className="warning-box" style={{ marginBottom: '0.75rem' }}>
+                <strong>Locked:</strong> Unlock to make changes
               </div>
-
-              {/* Lock/Unlock */}
+            )}
+            <div className="row between wrap" style={{ gap: '0.5rem' }}>
+              <h4 style={{ margin: 0 }}>Your Remaining Domain Power</h4>
               <button
                 className={isLocked ? 'btn-danger' : 'btn-success'}
                 onClick={toggleLock}
-                style={{ width: '100%', padding: '1rem' }}
+                style={{ padding: '0.65rem 1rem' }}
               >
                 {isLocked ? 'Unlock Allocations' : 'Lock In Allocations'}
               </button>
+            </div>
+            <div className="row wrap" style={{ gap: '0.4rem', marginTop: '0.65rem' }}>
+              {Object.entries(myDomains).map(([domain, capacity]) => {
+                const remaining = remainingByDomain[domain] || 0;
+                return (
+                  <span key={domain} className="pill" style={{ fontSize: '0.75rem' }}>
+                    {DOMAIN_NAMES[domain] || domain}: {remaining}/{capacity}
+                  </span>
+                );
+              })}
+            </div>
+            {!isLocked && totalRemaining > 0 && (
+              <div className="small muted" style={{ marginTop: '0.45rem' }}>
+                Unallocated power remaining: <strong>{totalRemaining}</strong>
+              </div>
+            )}
+          </div>
 
-              {/* Trial Selection */}
-              {!isLocked && (
-                <div className="card">
-                  <h4>Select Trial to Allocate Power</h4>
-                  <div className="stack" style={{ marginTop: '1rem' }}>
-                    {availableTrials.map(trial => {
-                      const trialAlloc = allocations[trial.id] || {};
-                      const trialTotal = Object.values(trialAlloc).reduce((sum, v) => sum + v, 0);
-                      const feedback = getValidationFeedback(trial, trialAlloc);
-                      const rp = recognitionTable[trial.id] || {};
-                      const rpText = playerCount >= 6 ? `${rp[1] || 0}/${rp[2] || 0} RP` : `${rp[1] || 0} RP`;
+          <div className="stack">
+            {availableTrials.map((trial, idx) => {
+              const trialAlloc = allocations[trial.id] || {};
+              const trialTotal = Object.values(trialAlloc).reduce((sum, v) => sum + v, 0);
+              const feedback = getValidationFeedback(trial, trialAlloc);
+              const rp = recognitionTable[trial.id] || {};
+              const rewardLabel = playerCount >= 6
+                ? `Reward: ${rp[1] || 0}/${rp[2] || 0} ${TEXT.pointsAbbreviation}`
+                : `Reward: ${rp[1] || 0} ${TEXT.pointsAbbreviation}`;
+              const hasRegularPower = Object.entries(trialAlloc).some(([d, v]) => d !== 'wilds' && v > 0);
+              const currentSources = Object.keys(trialAlloc).filter(d => (trialAlloc[d] || 0) > 0 && d !== 'wilds');
+              const availableDomains = trial.getAvailableDomains(currentSources);
+              const shownDomains = Object.keys(myDomains).filter((domain) => {
+                if (domain === 'wilds') return true;
+                return availableDomains.includes(domain) || (trialAlloc[domain] || 0) > 0;
+              });
+              const detailsOpen = idx === 0 || trialTotal > 0;
+
+              return (
+                <details key={trial.id} className="trial-card" open={detailsOpen}>
+                  <summary>
+                    <div className="row between" style={{ gap: '0.5rem' }}>
+                      <strong>{trial.name}</strong>
+                      <span className="pill" style={{ fontSize: '0.72rem' }}>{rewardLabel}</span>
+                    </div>
+                    <div className="small muted" style={{ marginTop: '0.35rem' }}>{trial.description}</div>
+                    <div className="row between wrap" style={{ marginTop: '0.45rem', gap: '0.45rem' }}>
+                      <span className="small">
+                        Your allocation: <strong>{trialTotal}</strong>
+                      </span>
+                      {feedback && (
+                        <span className="small" style={{ color: feedback.type === 'valid' ? 'var(--green)' : 'var(--red)' }}>
+                          {feedback.type === 'valid' ? 'Valid setup' : 'Needs valid setup'}
+                        </span>
+                      )}
+                    </div>
+                    <div className="wizard-compact-list" onClick={(e) => e.preventDefault()}>
+                      {players.filter(p => p.id !== MY_ID).map(w => {
+                        const domainTotal = shownDomains.reduce((sum, d) => sum + (w.domains?.[d] || 0), 0);
+                        const tooltip = `${w.name}: ${shownDomains.map(d => `${DOMAIN_NAMES[d] || d} ${w.domains?.[d] || 0}`).join(', ')}`;
+                        return (
+                          <span key={w.id} className="wizard-compact-chip" title={tooltip}>
+                            <span className="wizard-initial" style={getWizardStyle(w.name)}>{getInitials(w.name)}</span>
+                            <span>{domainTotal}</span>
+                          </span>
+                        );
+                      })}
+                    </div>
+                  </summary>
+
+                  <div style={{ padding: '0 0.75rem 0.7rem' }}>
+                    {!isLocked && (
+                      <div style={{ display: 'flex', justifyContent: 'flex-end', marginBottom: '0.25rem' }}>
+                        <button className="btn-danger small" onClick={() => clearTrial(trial.id)} style={{ minWidth: '72px' }}>Clear</button>
+                      </div>
+                    )}
+                    {shownDomains.map((domain) => {
+                      const currentAlloc = trialAlloc[domain] || 0;
+                      const remaining = remainingByDomain[domain] || 0;
+                      const maxAllowable = remaining + currentAlloc;
+                      const isWild = domain === 'wilds';
+                      const isDomainAvailable = isWild || availableDomains.includes(domain);
+                      const isDisabled = isLocked || ((isWild && !hasRegularPower) || !isDomainAvailable);
+
                       return (
-                        <button
-                          key={trial.id}
-                          onClick={() => setSelectedTrial(trial.id)}
-                          className={`trial-selection-btn ${selectedTrial === trial.id ? 'btn-primary' : 'btn-secondary'}`}
-                          style={{
-                            width: '100%', textAlign: 'left', padding: '1rem',
-                            border: feedback?.type === 'valid' ? '2px solid rgba(34, 197, 94, 0.5)' : undefined,
-                            background: feedback?.type === 'valid' ? 'rgba(34, 197, 94, 0.1)' : undefined
-                          }}
-                        >
-                          <div className="row between" style={{ marginBottom: '0.5rem' }}>
-                            <strong>{trial.name}</strong>
-                            <span className="pill" style={{ fontSize: '0.75rem', padding: '0.25rem 0.5rem' }}>{rpText}</span>
+                        <div key={`${trial.id}-${domain}`} className="trial-adjust-row" style={{ opacity: isDisabled ? 0.65 : 1 }}>
+                          <div>
+                            <div className="small">
+                              <strong>{DOMAIN_NAMES[domain] || domain}</strong>
+                              {!isDomainAvailable && !isWild && ' (not available)'}
+                            </div>
+                            <div className="small muted">
+                              Your available: {maxAllowable} {isWild && !hasRegularPower ? '• Add regular power first' : ''}
+                            </div>
                           </div>
-                          <div className="small muted">{trial.description}</div>
-                          {trialTotal > 0 && <div style={{ marginTop: '0.5rem' }}><span className="highlight" style={{ fontSize: '0.9rem' }}>Total: {trialTotal}</span></div>}
-                        </button>
+                          <div className="trial-adjust-controls">
+                            <button
+                              className="btn-secondary"
+                              onClick={() => nudgeAllocation(trial.id, domain, -1)}
+                              disabled={isDisabled || currentAlloc <= 0}
+                              aria-label={`Decrease ${DOMAIN_NAMES[domain] || domain} in ${trial.name}`}
+                            >−</button>
+                            <input
+                              type="number"
+                              min="0"
+                              max={maxAllowable}
+                              value={currentAlloc || ''}
+                              placeholder="0"
+                              onFocus={(e) => e.target.select()}
+                              onChange={(e) => updateAllocation(trial.id, domain, clampAllocation(trial.id, domain, parseInt(e.target.value) || 0))}
+                              disabled={isDisabled}
+                              aria-label={`${DOMAIN_NAMES[domain] || domain} allocation for ${trial.name}`}
+                            />
+                            <button
+                              className="btn-secondary"
+                              onClick={() => nudgeAllocation(trial.id, domain, 1)}
+                              disabled={isDisabled || currentAlloc >= maxAllowable}
+                              aria-label={`Increase ${DOMAIN_NAMES[domain] || domain} in ${trial.name}`}
+                            >+</button>
+                          </div>
+                        </div>
                       );
                     })}
                   </div>
-                </div>
-              )}
-
-              {totalRemaining > 0 && !isLocked && (
-                <div className="note"><strong>Note:</strong> You have {totalRemaining} unallocated power remaining</div>
-              )}
-            </div>
-
-            {/* Right column: Trial allocation detail */}
-            {selectedTrial && !isLocked && (
-              <div className="card">
-                {(() => {
-                  const trial = availableTrials.find(t => t.id === selectedTrial);
-                  if (!trial) return null;
-                  const trialAlloc = allocations[trial.id] || {};
-                  const feedback = getValidationFeedback(trial, trialAlloc);
-
-                  return (
-                    <>
-                      <div className="row between wrap">
-                        <h4>{trial.name}</h4>
-                        <button className="btn-danger" onClick={() => clearTrial(trial.id)} style={{ minWidth: '80px' }}>Clear</button>
-                      </div>
-                      <p className="small muted" style={{ marginTop: '0.5rem' }}>{trial.description}</p>
-
-                      {feedback && (
-                        <div className={feedback.type === 'valid' ? 'info-box' : 'warning-box'} style={{
-                          marginTop: '1rem',
-                          background: feedback.type === 'valid' ? 'rgba(34, 197, 94, 0.15)' : undefined,
-                          border: feedback.type === 'valid' ? '1px solid rgba(34, 197, 94, 0.4)' : undefined
-                        }}>
-                          {feedback.message}
-                        </div>
-                      )}
-
-                      <div className="domain-grid" style={{ marginTop: '1rem' }}>
-                        {Object.entries(myDomains).map(([domain, capacity]) => {
-                          const currentAlloc = trialAlloc[domain] || 0;
-                          const remaining = remainingByDomain[domain] || 0;
-                          const maxAllowable = remaining + currentAlloc;
-                          const isWild = domain === 'wilds';
-                          const hasRegularPower = Object.entries(trialAlloc).some(([d, v]) => d !== 'wilds' && v > 0);
-                          const currentSources = Object.keys(trialAlloc).filter(d => (trialAlloc[d] || 0) > 0 && d !== 'wilds');
-                          const availableDomains = trial.getAvailableDomains(currentSources);
-                          const isDomainAvailable = isWild || availableDomains.includes(domain);
-                          const isDisabled = (isWild && !hasRegularPower) || !isDomainAvailable;
-
-                          return (
-                            <div key={domain} className="domain-item" style={{ opacity: isDomainAvailable || isWild ? 1 : 0.4 }}>
-                              <div className="field">
-                                <label className="small" style={{ opacity: isDomainAvailable || isWild ? 1 : 0.6 }}>
-                                  {DOMAIN_NAMES[domain] || domain}
-                                  {!isDomainAvailable && !isWild && ' (not available)'}
-                                </label>
-                                {isWild && !hasRegularPower && (
-                                  <p className="small muted" style={{ fontSize: '0.7rem', marginBottom: '0.25rem', fontStyle: 'italic' }}>Add regular power first</p>
-                                )}
-                                <input
-                                  type="number" min="0" max={maxAllowable} value={currentAlloc || ''}
-                                  placeholder="0"
-                                  onFocus={(e) => e.target.select()}
-                                  onChange={(e) => updateAllocation(trial.id, domain, e.target.value)}
-                                  disabled={isDisabled}
-                                  style={{
-                                    opacity: isDisabled ? 0.5 : 1,
-                                    cursor: isDisabled ? 'not-allowed' : 'text',
-                                    background: isDisabled ? 'var(--card-bg)' : undefined
-                                  }}
-                                />
-                                <div className="small muted" style={{ marginTop: '0.25rem', fontSize: '0.75rem' }}>Available: {maxAllowable}</div>
-                              </div>
-                            </div>
-                          );
-                        })}
-                      </div>
-                    </>
-                  );
-                })()}
-              </div>
-            )}
+                </details>
+              );
+            })}
           </div>
         </div>
       );


### PR DESCRIPTION
### Motivation

- Players misread bare RP values and scrolled excessively; the UI should make RP clearly a reward and present each trial with the player’s available power and compact comparison to other wizards on a single mobile-portrait-friendly screen.  
- Keep existing allocation rules, validation and data model intact while improving clarity and reducing context switching.  
- Inputs must remain keyboard-usable and fast to operate on small screens.  

### Description

- Changed trial payout labels to explicit reward text (e.g. `Reward: 8 RP` and `Reward: X/Y RP` for 6+ players) so RP cannot be confused with input.  
- Replaced the old split selector → detail panel flow with inline collapsible trial cards using `<details>`/`summary`, so reward, description, your current allocation, and compact other-wizard comparison appear together per trial.  
- Added a sticky allocation header (`.allocation-sticky-header`) that shows per-domain remaining/capacity and lock/unlock controls so remaining power is always visible while scrolling.  
- Introduced compact other-wizard chips (initials + deterministic color + relevant-domain totals with tooltip) and inline quick-adjust controls for allocations (`−` / number input / `+`) with clamping logic (`clampAllocation`, `nudgeAllocation`) while preserving keyboard-accessible native `input[type="number"]`.  
- Presentation-only changes: no allocation rules, validation, or Firebase payloads were altered; existing functions for validation and saving remain in use.  

### Testing

- Basic repository checks and commit performed: `git status --short` and `git show --stat --oneline HEAD` executed and succeeded.  
- No automated unit/UI test suite was present or run for this change; the edit is a client-side presentation refactor and relies on manual/visual QA in mobile portrait sizes (`375x667`, `414x896`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69ef672c4f988324aaba81d029109730)